### PR TITLE
cleanup build types and dep resolution, migrate metatdata, populate manifest.in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,5 +101,5 @@ jobs:
         if [ "$RUNNER_OS" == "Windows" ]; then
           echo "I am still broken on windows..."
         else
-          tox -e py
+          tox -e deploy
         fi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.rst LICENSE
+global-include CMakeLists.txt *.cmake
+exclude *.sh *.ini req*
+prune .git*

--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,10 @@ A drop-in replacement for the re module.
 It uses RE2 under the hood, of course, so various PCRE features
 (e.g. backreferences, look-around assertions) are not supported.
 
-..note:: The original source for this module lives on a separate branch in the
-         `RE2 library repository`_ in the ``python`` subdirectory.
+
+.. note:: The original source for this module lives on a separate branch in the
+          `RE2 library repository`_ in the ``python`` subdirectory.
+
 
 .. _RE2 library repository: https://github.com/google/re2/tree/abseil/python
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[metadata]
+name = google-re2
+author = The RE2 Authors
+author_email = re2-dev@googlegroups.com
+description = RE2 Python bindings
+long_description = file: README.rst
+long_description_content_type = text/x-rst; charset=UTF-8
+url = https://github.com/freepn/google-re2
+license = BSD
+license_files = LICENSE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Programming Language :: C++
+    Programming Language :: Python :: 3.6
+
+[options]
+python_requires = >=3.6
+
+install_requires =
+    six
+
+py_modules =
+    re2
+
+[options.extras_require]
+test =
+    pytest
+    absl-py

--- a/setup.py
+++ b/setup.py
@@ -11,32 +11,6 @@ from pybind11.setup_helpers import Pybind11Extension, build_ext
 from pybind11 import get_include
 
 
-long_description = """\
-A drop-in replacement for the re module.
-
-It uses RE2 under the hood, of course, so various PCRE features
-(e.g. backreferences, look-around assertions) are not supported.
-
-Known differences between this API and the re module's API:
-
-  * The error class does not provide any error information as attributes.
-  * The Options class replaces the re module's flags with RE2's options as
-    gettable/settable properties. Please see re2.h for their documentation.
-  * The pattern string and the input string do not have to be the same type.
-    Any Text (unicode in Python 2, str in Python 3) will be encoded to UTF-8.
-  * The pattern string cannot be Text if the options specify Latin-1 encoding.
-
-Known issues with regard to building the C++ extension:
-
-  * Building requires RE2 to be installed on your system.
-    On Debian, for example, install the libre2-dev package.
-  * Building requires pybind11 to be installed on your system OR venv.
-    On Debian, for example, install the pybind11-dev package.
-    For a venv, install the pybind11 package from PyPI.
-  * Building on macOS has not been tested yet and will possibly fail.
-  * Building on Windows has not been tested yet and will probably fail.
-"""
-
 __version__ = '0.0.7'
 
 ext_modules = [
@@ -50,28 +24,10 @@ ext_modules = [
 ]
 
 setup(
-    name='google-re2',
     version=__version__,
-    description='RE2 Python bindings',
-    long_description=long_description,
-    long_description_content_type='text/plain',
-    url='https://github.com/google/re2',
-    author='The RE2 Authors',
-    author_email='re2-dev@googlegroups.com',
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: C++',
-        'Programming Language :: Python :: 3.6',
-    ],
     ext_modules=ext_modules,
     # Currently, build_ext only provides an optional "highest supported C++
     # level" feature, but in the future it may provide more features.
     cmdclass={"build_ext": build_ext},
     zip_safe=False,
-    py_modules=['re2'],
-    python_requires='>=3.6',
-    install_requires=['six'],
-    extras_require={'test': ['pytest', 'absl-py']},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
     -rrequirements-dev.txt
 
 commands =
+    python -m pip install --upgrade wheel setuptools
     pip install .[test]
     py.test []
     #py.test . --cov --cov-report term-missing
@@ -29,7 +30,11 @@ passenv = CI PYTHON CC CXX
 deps =
     pip>=19.0.1
     wheel
+    # tox barfs without this dep; the same cmds work fine in venv
+    pybind11
 
 commands =
-    python setup.py sdist
+    python -m pip install twine build
+    python -m build -s
+    twine check dist/*
     python setup.py bdist_wheel


### PR DESCRIPTION
Requirements for using ``pybind11`` in setup.py:

* included in the build system requirements, but *not* in install_requires
* required in the host build environment (installed via system package manager)
* for whatever reason, tox needs it as an explicit dependency for building wheels (see [testenv:deploy] in tox.ini)
